### PR TITLE
cache modConcat output

### DIFF
--- a/example-app/server.js
+++ b/example-app/server.js
@@ -121,14 +121,6 @@ function httpResHandler(req, res) {
 		// it needs ran through modConcat
 		concatAndCache(__dirname, req, res);
 
-		/*
-		const src = new modConcat.ModuleConcatStream(__dirname + "/client.js", {
-			"browser": true
-		});
-		res.setHeader("Content-Type", "text/javascript");
-		src.pipe(res);
-		*/
-		
 	} else {
 		res.statusCode = 404;
 		res.end("Not Found");


### PR DESCRIPTION
I wrote a routine called concatAndCache() for use in server.js in the example app. The routine caches the output of modConcat and only regenerates when necessary. 